### PR TITLE
Add optional ssh_key_file argument

### DIFF
--- a/database/variables.tf
+++ b/database/variables.tf
@@ -39,7 +39,7 @@ variable "name" {
 }
 
 variable "password" {
-  default = "provisioner_password"
+  default = ""
 }
 
 variable "username" {


### PR DESCRIPTION
If provided, it will try and create a ssh key in AWS with the ssh_key_name
argument and use it to launch the worker instances