### PR TITLE
use tls provider to effectively generate a stable, random default password for databases

### DIFF
--- a/database/variables.tf
+++ b/database/variables.tf
@@ -39,7 +39,7 @@ variable "name" {
 }
 
 variable "password" {
-  default = "provisioner_password"
+  default = ""
 }
 
 variable "username" {


### PR DESCRIPTION
Note that this is a work-around until TF 0.7

Helps #2