### PR TITLE
Don't use the dualstack ELB name, as it will offer ipv6 addresses which don't work

### DIFF
--- a/load_balancer/outputs.tf
+++ b/load_balancer/outputs.tf
@@ -1,5 +1,5 @@
 output "address" {
-  value = "dualstack.${aws_elb.load_balancer.dns_name}"
+  value = "${aws_elb.load_balancer.dns_name}"
 }
 
 output "ipv4_address" {


### PR DESCRIPTION
Fixes #14