### PR TITLE
Lower ELB idle_timeout/connection_draining_timeout to 60sec

### DIFF
--- a/load_balancer/main.tf
+++ b/load_balancer/main.tf
@@ -94,9 +94,9 @@ resource "aws_elb" "load_balancer" {
   }
 
   cross_zone_load_balancing   = true
-  idle_timeout                = 400
+  idle_timeout                = 60
   connection_draining         = true
-  connection_draining_timeout = 400
+  connection_draining_timeout = 60
 
   tags = {
     Name           = "${var.service_name}-${var.environment}"


### PR DESCRIPTION
The AWS default

Fixes #21