### PR TITLE
[database] Add a monitoring (default false) paramater to launch a db-admin host

### DIFF
--- a/database/variables.tf
+++ b/database/variables.tf
@@ -61,3 +61,7 @@ variable "multi_az" {
 variable "parameter_group_name" {
   default = ""
 }
+
+variable "monitoring" {
+  default = false
+}


### PR DESCRIPTION
Cute side effect is auto-publishing DB information to Consul under

<stack-name>/<env>/config/Database/*

Fixes #49