### PR TITLE
[bucket] Add s3:*Acl permissions for consumers

### DIFF
--- a/bucket/main.tf
+++ b/bucket/main.tf
@@ -59,7 +59,9 @@ resource "aws_iam_role_policy" "bucket" {
               "Effect": "Allow",
               "Action": [
                 "s3:PutObject",
+                "s3:PutObjectAcl",
                 "s3:GetObject",
+                "s3:GetObjectAcl",
                 "s3:DeleteObject"
               ],
               "Resource": "${aws_s3_bucket.bucket.arn}/*"


### PR DESCRIPTION
Added
 - s3:PutObjectAcl
 - s3:GetObjectAcl

To the IAM Role for bucket owners

Fixes #63