### PR TITLE
Fixes #127 by adding ability to configure idle_timeout

### DIFF
--- a/load_balancer/main.tf
+++ b/load_balancer/main.tf
@@ -102,7 +102,7 @@ resource "aws_elb" "load_balancer" {
   }
 
   cross_zone_load_balancing   = true
-  idle_timeout                = 60
+  idle_timeout                = "${var.idle_timeout}"
   connection_draining         = true
   connection_draining_timeout = 60
   internal                    = "${var.internal}"

--- a/load_balancer/variables.tf
+++ b/load_balancer/variables.tf
@@ -67,3 +67,7 @@ variable "internal" {
 variable "arena" {
   default = "core"
 }
+
+variable "idle_timeout" {
+  default = "60"
+}


### PR DESCRIPTION
Please see issue #127 for details. This will allow us to override the default timeout of 60 seconds.