### PR TITLE
Fixes #136 by adding a session affinity feature

### DIFF
--- a/load_balancer/main.tf
+++ b/load_balancer/main.tf
@@ -120,3 +120,19 @@ resource "aws_elb" "load_balancer" {
     create_before_destroy = true
   }
 }
+
+resource "aws_lb_cookie_stickiness_policy" "load_balancer_stickiness_http" {
+  count                    = "${var.enable_session_affinity}"
+  name                     = "${var.service_name}-${var.environment}-elb-stickiness-policy-http"
+  load_balancer            = "${aws_elb.load_balancer.id}"
+  lb_port                  = 80
+  cookie_expiration_period = 600
+}
+
+resource "aws_lb_cookie_stickiness_policy" "load_balancer_stickiness_https" {
+  count                    = "${var.enable_session_affinity}"
+  name                     = "${var.service_name}-${var.environment}-elb-stickiness-policy-https"
+  load_balancer            = "${aws_elb.load_balancer.id}"
+  lb_port                  = 443
+  cookie_expiration_period = 600
+}

--- a/load_balancer/variables.tf
+++ b/load_balancer/variables.tf
@@ -71,3 +71,7 @@ variable "arena" {
 variable "idle_timeout" {
   default = "60"
 }
+
+variable "enable_session_affinity" {
+  default = false
+}


### PR DESCRIPTION
I only wanted to enable the resource creation if we set session affinity to true. I found some recommendations on how to work around Terraform's lack of if logic. Feel free to suggest changes if you're not comfortable with my chosen method.

In this PR, a boolean in the `variables.tf` file determines the count for the new resources.

Resources:
https://blog.gruntwork.io/terraform-tips-tricks-loops-if-statements-and-gotchas-f739bbae55f9
https://github.com/hashicorp/terraform/issues/15281#issuecomment-308275154