### PR TITLE
[worker] health_check_grace_period default to 10 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,4 @@
 language: generic
-addons:
-  apt:
-    sources:
-    - debian-sid
-    packages:
-    - libssl1.0.0
 before_install:
 - wget --debug --no-check-certificate -v -O terraform.zip "https://releases.hashicorp.com/terraform/0.10.5/terraform_0.10.5_linux_amd64.zip"
 - unzip -o terraform.zip -d $HOME/bin

--- a/worker/variables.tf
+++ b/worker/variables.tf
@@ -75,7 +75,7 @@ variable "health_check_type" {
 }
 
 variable "health_check_grace_period" {
-  default = "300"
+  default = "600"
 }
 
 variable "elb" {


### PR DESCRIPTION
The current value of 5 minutes was to close to our average node bootup time

Fixes #88