### PR TITLE
Don't wait for ELB health status when not using ELB for health checking

### DIFF
--- a/worker/main.tf
+++ b/worker/main.tf
@@ -128,7 +128,9 @@ resource "aws_autoscaling_group" "asg" {
   ]
 
   wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
-  wait_for_elb_capacity     = "${signum(length(var.elb)) * var.min_instances}"
+
+  # Only wait if health_check_type is ELB
+  wait_for_elb_capacity     = "${coalesce(var.health_check_type, lookup(var.health_check_type_map, signum(length(var.elb)))) == "ELB" ? var.min_instances : 0}"
 
   enabled_metrics = [
     "GroupMinSize",

--- a/worker/main.tf
+++ b/worker/main.tf
@@ -130,7 +130,7 @@ resource "aws_autoscaling_group" "asg" {
   wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
 
   # Only wait if health_check_type is ELB
-  wait_for_elb_capacity     = "${coalesce(var.health_check_type, lookup(var.health_check_type_map, signum(length(var.elb)))) == "ELB" ? var.min_instances : 0}"
+  wait_for_elb_capacity = "${coalesce(var.health_check_type, lookup(var.health_check_type_map, signum(length(var.elb)))) == "ELB" ? var.min_instances : 0}"
 
   enabled_metrics = [
     "GroupMinSize",


### PR DESCRIPTION
Long standing bug, causing deploys to timeout when using an ELB but setting health-checks to EC2

Fixes #55