### PR TITLE
Add initial support for external monitoring with NewRelic Synthetic

### DIFF
--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -28,7 +28,7 @@ resource "nrs_monitor" "monitor" {
 }
 
 data "template_file" "script" {
-  template = "${file(var.script_template)}"
+  template = "${file(coalesce(var.script_template, "${path.module}/templates/script.tpl"))}"
 
   vars {
     URL = "${var.url}"

--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -28,7 +28,7 @@ resource "nrs_monitor" "monitor" {
 }
 
 data "template_file" "script" {
-  template = "var site_url = '$${URL}';\n${var.script_template}"
+  template = "${file(var.script_template)}"
 
   vars {
     URL = "${var.url}"

--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -1,21 +1,21 @@
 resource "nrs_monitor" "monitor" {
-  name = "${var.account}-${var.service_name}-${var.environment}"
+  name = "${var.account}-${var.arena}-${var.region}-${var.service_name}-${var.environment}"
 
   // The monitor's checking frequency in minutes (one of 1, 5, 10,
   // 15, 30, 60, 360, 720, or 1440).
-  frequency = 60
+  frequency = "${var.frequency}"
 
   // The monitoring locations. A list can be found at the endpoint:
   // https://synthetics.newrelic.com/synthetics/api/v1/locations
-  locations = ["AWS_US_WEST_1", "LINODE_US_SOUTH_1"]
+  locations = "${var.locations}"
 
-  status = "ENABLED"
+  status = "${var.status}"
 
   // The type of monitor (one of SIMPLE, BROWSER, SCRIPT_API,
   // SCRIPT_BROWSER)
-  type = "SCRIPT_BROWSER"
+  type = "${var.type}"
 
-  sla_threshold = 1
+  sla_threshold = "${var.sla_treshold}"
 
   // The URI to check. This only applies to SIMPLE and BROWSER
   // monitors.
@@ -24,11 +24,13 @@ resource "nrs_monitor" "monitor" {
   // The API or browser script to execute. This only applies to
   // SCRIPT_API or SCRIPT_BROWSER monitors. Docs can be found here:
   // https://docs.newrelic.com/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers
-  script = <<EOF
-  var site_url = "${var.url}"
+  script = "${data.template_file.script.rendered}"
+}
 
-  console.log('running test for ' + site_url + ' in ' + $env.LOCATION);
+data "template_file" "script" {
+  template = "${var.script_template}"
 
-  $browser.get(site_url);
-EOF
+  vars {
+    URL = "${var.url}"
+  }
 }

--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -1,0 +1,34 @@
+resource "nrs_monitor" "monitor" {
+  name = "${var.account}-${var.service_name}-${var.environment}"
+
+  // The monitor's checking frequency in minutes (one of 1, 5, 10,
+  // 15, 30, 60, 360, 720, or 1440).
+  frequency = 60
+
+  // The monitoring locations. A list can be found at the endpoint:
+  // https://synthetics.newrelic.com/synthetics/api/v1/locations
+  locations = ["AWS_US_WEST_1", "LINODE_US_SOUTH_1"]
+
+  status = "ENABLED"
+
+  // The type of monitor (one of SIMPLE, BROWSER, SCRIPT_API,
+  // SCRIPT_BROWSER)
+  type = "SCRIPT_BROWSER"
+
+  sla_threshold = 1
+
+  // The URI to check. This only applies to SIMPLE and BROWSER
+  // monitors.
+  uri = "${var.url}"
+
+  // The API or browser script to execute. This only applies to
+  // SCRIPT_API or SCRIPT_BROWSER monitors. Docs can be found here:
+  // https://docs.newrelic.com/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers
+  script = <<EOF
+  var site_url = "${var.url}"
+
+  console.log('running test for ' + site_url + ' in ' + $env.LOCATION);
+
+  $browser.get(site_url);
+EOF
+}

--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -28,7 +28,7 @@ resource "nrs_monitor" "monitor" {
 }
 
 data "template_file" "script" {
-  template = "${var.script_template}"
+  template = "var site_url = '$${URL}';\n${var.script_template}"
 
   vars {
     URL = "${var.url}"

--- a/monitoring/templates/script.tpl
+++ b/monitoring/templates/script.tpl
@@ -1,0 +1,7 @@
+var site_url = '${URL}';
+
+// Simplest browser test, just load the home page and call it good
+
+console.log('running test for ' + site_url + ' in ' + $env.LOCATION);
+
+$browser.get(site_url);

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -21,3 +21,47 @@ variable "technical_owner" {
 }
 
 variable "url" {}
+
+// Check interval in minutes
+// Allowed values: 1, 5, 10, 15, 30, 60, 360, 720, or 1440
+variable "frequency" {
+  default = "60"
+}
+
+// SLA Treshold
+variable "sla_treshold" {
+  default = 7
+}
+
+//
+variable "status" {
+  default = "ENABLED"
+}
+
+// The type of monitor (one of SIMPLE, BROWSER, SCRIPT_API,
+// SCRIPT_BROWSER)
+variable "type" {
+  default = "SCRIPT_BROWSER"
+}
+
+// The monitoring locations. A list can be found at the endpoint:
+// https://synthetics.newrelic.com/synthetics/api/v1/locations
+variable "locations" {
+  type = "list"
+
+  default = [
+    "AWS_US_WEST_1",
+    "LINODE_US_SOUTH_1",
+  ]
+}
+
+variable "script_template" {
+  default = <<EOF
+// Simplest browser test, just load the home page and call it good \
+var site_url = '$${URL}' \
+
+console.log('running test for ' + site_url + ' in ' + $env.LOCATION);
+
+$browser.get(site_url);
+EOF
+}

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -56,11 +56,5 @@ variable "locations" {
 }
 
 variable "script_template" {
-  default = <<EOF
-// Simplest browser test, just load the home page and call it good \
-
-console.log('running test for ' + site_url + ' in ' + $env.LOCATION);
-
-$browser.get(site_url);
-EOF
+  default = "${path.module}/templates/script.tpl"
 }

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -56,5 +56,5 @@ variable "locations" {
 }
 
 variable "script_template" {
-  default = "${path.module}/templates/script.tpl"
+  default = ""
 }

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -58,7 +58,6 @@ variable "locations" {
 variable "script_template" {
   default = <<EOF
 // Simplest browser test, just load the home page and call it good \
-var site_url = '$${URL}' \
 
 console.log('running test for ' + site_url + ' in ' + $env.LOCATION);
 

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -1,0 +1,23 @@
+variable "account" {}
+
+variable "region" {}
+
+variable "environment" {}
+
+variable "arena" {
+  default = "core"
+}
+
+variable "nubis_domain" {
+  default = "nubis.allizom.org"
+}
+
+variable "service_name" {
+  default = "nubis"
+}
+
+variable "technical_owner" {
+  default = "infra-aws@mozilla.com"
+}
+
+variable "url" {}


### PR DESCRIPTION
Example usage is like so:

```terraform
module "monitoring" {
  source       = "github.com/nubisproject/nubis-terraform//monitoring?ref=develop"
  region       = "${var.region}"
  environment  = "${var.environment}"
  account      = "${var.account}"
  service_name = "${var.service_name}"
  url          = "https://${module.dns.fqdn}/"
}

```

Configurable options are:
 - url
 - frequency (in minutes) (default:60) (Allowed values: 1, 5, 10, 15, 30, 60, 360, 720, or 1440)
 - sla_treshold (default:7)
 - status (default:ENABLED) (ENABLED/DISABLED)
 - type (default: SCRIPT_BROWSER) (Allowed values: SIMPLE, BROWSER, SCRIPT_API, SCRIPT_BROWSER)
 - locations (default: ["AWS_US_WEST_1", "LINODE_US_SOUTH_1"]) (Allowed values from https://synthetics.newrelic.com/synthetics/api/v1/locations)
 - script_template (default: simple page load script) 

Fixes #151