### PR TITLE
We don't need account-info for buckets, so don't use it

### DIFF
--- a/bucket/main.tf
+++ b/bucket/main.tf
@@ -1,10 +1,3 @@
-module "info" {
-  source      = "../info"
-  region      = "${var.region}"
-  environment = "${var.environment}"
-  account     = "${var.account}"
-}
-
 provider "aws" {
   region = "${var.region}"
 }


### PR DESCRIPTION
Otherwise, we can't create bucket in other regions

Fixes #186