### PR TITLE
[bucket] Allow specifying expiration rules and transitions

### DIFF
--- a/bucket/main.tf
+++ b/bucket/main.tf
@@ -40,6 +40,45 @@ resource "aws_s3_bucket" "bucket" {
     index_document = "${var.website_index}"
   }
 
+  lifecycle_rule {
+    id      = "expiration"
+    enabled = "${var.expiration_days >= "0" ? true : false }"
+
+    expiration {
+      days = "${var.expiration_days}"
+    }
+  }
+
+  lifecycle_rule {
+    id      = "transition-onezone_ia"
+    enabled = "${lookup(var.transitions, "ONEZONE_IA", 0) >= "30" ? true : false }"
+
+    transition {
+      days          = "${lookup(var.transitions, "ONEZONE_IA", 0) >= "30" ? lookup(var.transitions, "ONEZONE_IA", 0) : 30 }"
+      storage_class = "ONEZONE_IA"
+    }
+  }
+
+  lifecycle_rule {
+    id      = "transition-standard_ia"
+    enabled = "${lookup(var.transitions, "STANDARD_IA", 0) >= "30" ? true : false }"
+
+    transition {
+      days          = "${lookup(var.transitions, "STANDARD_IA", 0) >= "30" ? lookup(var.transitions, "STANDARD_IA", 0) : 30 }"
+      storage_class = "STANDARD_IA"
+    }
+  }
+
+  lifecycle_rule {
+    id      = "transition-glacier"
+    enabled = "${lookup(var.transitions, "GLACIER", 0) == "0" ? false : true }"
+
+    transition {
+      days          = "${lookup(var.transitions, "GLACIER", 0)}"
+      storage_class = "GLACIER"
+    }
+  }
+
   server_side_encryption_configuration = "${local.server_side_encryption_configuration_enabled[signum(var.storage_encrypted_at_rest)]}"
 
   tags = {

--- a/bucket/variables.tf
+++ b/bucket/variables.tf
@@ -34,3 +34,17 @@ variable "arena" {
 variable "storage_encrypted_at_rest" {
   default = false
 }
+
+variable "expiration_days" {
+  default = "0"
+}
+
+variable "transitions" {
+  type = "map"
+
+  default = {
+    STANDARD_IA = 0
+    ONEZONE_IA  = 0
+    GLACIER     = 0
+  }
+}


### PR DESCRIPTION
Introduced new variables:
 - expiration_days (default disabled) days after which to delete objects
 - transitions (default disabled) days to transitions to different storage
   - STANDARD_IA
   - ONEZONE_IA
   - GLACIER

Example:

```
module "bucket" {
  [...]
  expiration_days = "90"
  transitions = {
    "GLACIER" = 60
    "STANDARD_IA" = 30
  }
}
```

Fixes #192