### PR TITLE
Creates a new nubis-terraform module to provide CloudFront support

### DIFF
--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -46,12 +46,12 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   }
 
   viewer_certificate {
-    acm_certificate_arn = "${acm_certificate.arn}"
+    acm_certificate_arn = "${aws_acm_certificate.acm_tf.arn}"
     ssl_support_method  = "sni-only"
   }
 }
 
-data "aws_acm_certificate" "acm_certificate" {
+data "aws_acm_certificate" "acm_tf" {
   domain   = "${var.acm_certificate_domain}"
   statuses = ["ISSUED"]
 }

--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -11,7 +11,7 @@ provider "aws" {
 
 resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   origin {
-    domain_name = "${var.load_balancer_name}"
+    domain_name = "${var.load_balancer_web}"
     origin_id   = "${var.service_name}-${var.environment}"
   }
 

--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -1,0 +1,52 @@
+module "info" {
+  source      = "../info"
+  region      = "${var.region}"
+  environment = "${var.environment}"
+  account     = "${var.account}"
+}
+
+provider "aws" {
+  region = "${var.region}"
+}
+
+resource "aws_cloudfront_distribution" "cloudfront_distribution" {
+  origin {
+    domain_name = "${var.load_balancer_name}"
+    origin_id   = "${var.service_name}-${var.environment}"
+  }
+
+  enabled = true
+  comment = "${var.service_name}-${var.environment}"
+  aliases = "${var.domain_aliases}"
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${var.service_name}-${var.environment}"
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  tags {
+    Name           = "${var.service_name}-${var.environment}"
+    Region         = "${var.region}"
+    Environment    = "${var.environment}"
+    TechnicalOwner = "${var.technical_owner}"
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = "${var.acm_certificate_arn}"
+    ssl_support_method  = "sni-only"
+  }
+}

--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -46,7 +46,7 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   }
 
   viewer_certificate {
-    acm_certificate_arn = "${aws_acm_certificate.acm_tf.arn}"
+    acm_certificate_arn = "${data.aws_acm_certificate.acm_tf.arn}"
     ssl_support_method  = "sni-only"
   }
 }

--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -46,7 +46,12 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   }
 
   viewer_certificate {
-    acm_certificate_arn = "${var.acm_certificate_arn}"
+    acm_certificate_arn = "${acm_certificate.arn}"
     ssl_support_method  = "sni-only"
   }
+}
+
+data "aws_acm_certificate" "acm_certificate" {
+  domain   = "${var.acm_certificate_domain}"
+  statuses = ["ISSUED"]
 }

--- a/cloudfront/outputs.tf
+++ b/cloudfront/outputs.tf
@@ -1,0 +1,15 @@
+output "cloudfront_domain_name" {
+  value = "${aws_cloudfront_distribution.cloudfront_distribution.domain_name}"
+}
+
+output "cloudfront_status" {
+  value = "${aws_cloudfront_distribution.cloudfront_distribution.status}"
+}
+
+output "cloudfront_arn" {
+  value = "${aws_cloudfront_distribution.cloudfront_distribution.arn}"
+}
+
+output "cloudfront_id" {
+  value = "${aws_cloudfront_distribution.cloudfront_distribution.id}"
+}

--- a/cloudfront/variables.tf
+++ b/cloudfront/variables.tf
@@ -4,7 +4,7 @@ variable "region" {}
 
 variable "environment" {}
 
-variable "load_balancer_name" {}
+variable "load_balancer_web" {}
 
 variable "service_name" {
   default = "nubis"

--- a/cloudfront/variables.tf
+++ b/cloudfront/variables.tf
@@ -1,0 +1,28 @@
+variable "account" {}
+
+variable "region" {}
+
+variable "environment" {}
+
+variable "load_balancer_name" {}
+
+variable "service_name" {
+  default = "nubis"
+}
+
+variable "technical_owner" {
+  default = "infra-aws@mozilla.com"
+}
+
+variable "acm_ssl_cert_arn" {
+  default = ""
+}
+
+variable "domain_aliases" {
+  type    = "list"
+  default = []
+}
+
+variable "arena" {
+  default = "core"
+}

--- a/cloudfront/variables.tf
+++ b/cloudfront/variables.tf
@@ -14,7 +14,8 @@ variable "technical_owner" {
   default = "infra-aws@mozilla.com"
 }
 
-variable "acm_ssl_cert_arn" {
+# Provide the CN of the ACM certificate
+variable "acm_certificate_domain" {
   default = ""
 }
 


### PR DESCRIPTION
Hey,

I think we can probably review this PR as a team on Monday. I would like to collect feedback to see what you all would like to see in this module. Here's what I have so far:

- [X] Create a CloudFront distribution
- [X] Set origin to load_balancer_web public domain name
- [X] Terraform looks for an ACM certificate ARN with "Data Source: aws_acm_certificate". This requires us to manually create the SSL certificate in ACM. I'm comfortable with this for now if we intend on automating this in the future. I do not see a good way to use a certificate not managed by ACM
- [ ] Control caching through module inputs