### PR TITLE
corrects module count implementation and improves outputs

### DIFF
--- a/cloudfront/outputs.tf
+++ b/cloudfront/outputs.tf
@@ -1,15 +1,11 @@
 output "cloudfront_domain_name" {
-  value = "${aws_cloudfront_distribution.cloudfront_distribution.domain_name}"
-}
-
-output "cloudfront_status" {
-  value = "${aws_cloudfront_distribution.cloudfront_distribution.status}"
+  value = "${element(concat(aws_cloudfront_distribution.cloudfront_distribution.*.domain_name, list("")), 0)}"
 }
 
 output "cloudfront_arn" {
-  value = "${aws_cloudfront_distribution.cloudfront_distribution.arn}"
+  value = "${element(concat(aws_cloudfront_distribution.cloudfront_distribution.*.arn, list("")), 0)}"
 }
 
 output "cloudfront_id" {
-  value = "${aws_cloudfront_distribution.cloudfront_distribution.id}"
+  value = "${element(concat(aws_cloudfront_distribution.cloudfront_distribution.*.id, list("")), 0)}"
 }

--- a/cloudfront/variables.tf
+++ b/cloudfront/variables.tf
@@ -6,17 +6,16 @@ variable "environment" {}
 
 variable "load_balancer_web" {}
 
-variable "service_name" {
-  default = "nubis"
+variable "service_name" {}
+
+variable "acm_certificate_domain" {}
+
+variable "enabled" {
+  default = false
 }
 
 variable "technical_owner" {
   default = "infra-aws@mozilla.com"
-}
-
-# Provide the CN of the ACM certificate
-variable "acm_certificate_domain" {
-  default = ""
 }
 
 variable "domain_aliases" {


### PR DESCRIPTION
After testing locally, it looks like the following should correctly setup a CloudFront distribution when the module is enabled.