### PR TITLE
Don't configure AWS providers *inside* modules anymore

### DIFF
--- a/bucket/main.tf
+++ b/bucket/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = "${var.region}"
-}
-
 # Nasty workaround for nested optionnal block
 # Works, but edit carefully, if at all.
 locals {

--- a/cache/main.tf
+++ b/cache/main.tf
@@ -5,10 +5,6 @@ module "info" {
   account     = "${var.account}"
 }
 
-provider "aws" {
-  region = "${var.region}"
-}
-
 resource "aws_elasticache_cluster" "cache" {
   cluster_id        = "${var.service_name}-${var.environment}"
   engine            = "memcached"

--- a/database/main.tf
+++ b/database/main.tf
@@ -22,10 +22,6 @@ provider "consul" {
   datacenter = "${module.consul.datacenter}"
 }
 
-provider "aws" {
-  region = "${var.region}"
-}
-
 module "monitor-image" {
   source = "../images"
 

--- a/dns/main.tf
+++ b/dns/main.tf
@@ -5,10 +5,6 @@ module "info" {
   account     = "${var.account}"
 }
 
-provider "aws" {
-  region = "${var.region}"
-}
-
 resource "aws_route53_record" "primary" {
   count   = "${1 - ( var.ipv4_alias * var.ipv6_alias )}"
   zone_id = "${module.info.hosted_zone_id}"

--- a/images/main.tf
+++ b/images/main.tf
@@ -1,8 +1,3 @@
-provider "aws" {
-  version = "~> 0.1"
-  region  = "${var.region}"
-}
-
 data "aws_ami" "image" {
   most_recent = true
 

--- a/info/main.tf
+++ b/info/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = "${var.region}"
-}
-
 data "terraform_remote_state" "info" {
   backend = "http"
 

--- a/load_balancer/main.tf
+++ b/load_balancer/main.tf
@@ -5,10 +5,6 @@ module "info" {
   account     = "${var.account}"
 }
 
-provider "aws" {
-  region = "${var.region}"
-}
-
 resource "aws_security_group" "load_balancer" {
   name_prefix = "${var.service_name}-${var.environment}-"
 

--- a/mail/main.tf
+++ b/mail/main.tf
@@ -5,10 +5,6 @@ module "info" {
   account     = "${var.account}"
 }
 
-provider "aws" {
-  region = "${var.region}"
-}
-
 resource "aws_iam_access_key" "email" {
   user = "${aws_iam_user.email.name}"
 }

--- a/storage/main.tf
+++ b/storage/main.tf
@@ -21,10 +21,6 @@ provider "consul" {
   datacenter = "${module.consul.datacenter}"
 }
 
-provider "aws" {
-  region = "${var.region}"
-}
-
 resource "aws_efs_file_system" "storage" {
   tags = {
     Name           = "${var.service_name}-${var.environment}-storage"

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,0 +1,27 @@
+module "worker" {
+  source        = "../worker"
+  account       = "nubis-gozer"
+  region        = "us-west-2"
+  environment   = "stage"
+  service_name  = "gozer-test"
+  purpose       = "test"
+  ami           = "ami-eff28d97"
+  swap_size_meg = "1024"
+}
+
+module "database" {
+  source                 = "../database"
+  region                 = "us-west-2"
+  environment            = "stage"
+  account                = "nubis-gozer"
+  monitoring             = false
+  service_name           = "testdb"
+  client_security_groups = "${module.worker.security_group}"
+  name                   = "testdb"
+  engine                 = "postgres"
+  engine_version         = "9.5"
+  username               = "gozer"
+  monitoring             = true
+  multi_az               = true
+  replica_count          = 0
+}

--- a/worker/main.tf
+++ b/worker/main.tf
@@ -5,10 +5,6 @@ module "info" {
   account     = "${var.account}"
 }
 
-provider "aws" {
-  region = "${var.region}"
-}
-
 module "userdata" {
   source            = "./userdata"
   region            = "${var.region}"


### PR DESCRIPTION
Terraform 0.11 frowns upon that, instead, the idea is to configure the provider
in the top-level main.tf of the application

```
provider "aws" {
  region = "${var.region}"
}
```
See https://www.terraform.io/docs/modules/usage.html#providers-within-modules

Fixes #201