### PR TITLE
Add IPv6 support for the load balancer module

### DIFF
--- a/load_balancer/main.tf
+++ b/load_balancer/main.tf
@@ -11,24 +11,27 @@ resource "aws_security_group" "load_balancer" {
   vpc_id = "${module.info.vpc_id}"
 
   ingress {
-    from_port   = "${var.port_http}"
-    to_port     = "${var.port_http}"
-    protocol    = "tcp"
-    cidr_blocks = "${var.whitelist_cidrs}"
+    from_port        = "${var.port_http}"
+    to_port          = "${var.port_http}"
+    protocol         = "tcp"
+    cidr_blocks      = "${var.whitelist_cidrs}"
+    ipv6_cidr_blocks = "${var.whitelist_ipv6_cidrs}"
   }
 
   ingress {
-    from_port   = "${var.port_https}"
-    to_port     = "${var.port_https}"
-    protocol    = "tcp"
-    cidr_blocks = "${var.whitelist_cidrs}"
+    from_port        = "${var.port_https}"
+    to_port          = "${var.port_https}"
+    protocol         = "tcp"
+    cidr_blocks      = "${var.whitelist_cidrs}"
+    ipv6_cidr_blocks = "${var.whitelist_ipv6_cidrs}"
   }
 
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   tags = {

--- a/load_balancer/outputs.tf
+++ b/load_balancer/outputs.tf
@@ -2,6 +2,10 @@ output "address" {
   value = "${aws_elb.load_balancer.dns_name}"
 }
 
+output "dualstack_address" {
+  value = "dualstack.${aws_elb.load_balancer.dns_name}"
+}
+
 output "ipv4_address" {
   value = "${aws_elb.load_balancer.dns_name}"
 }

--- a/load_balancer/variables.tf
+++ b/load_balancer/variables.tf
@@ -84,3 +84,8 @@ variable "whitelist_cidrs" {
   type    = "list"
   default = ["0.0.0.0/0"]
 }
+
+variable "whitelist_ipv6_cidrs" {
+  type    = "list"
+  default = ["::/0"]
+}


### PR DESCRIPTION
Allows IPv6 CIDR blocks to make it possible to connect over IPv6.

Also added a dualstack output, since it's more desirable than IPv4 or IPv6 only.