### PR TITLE
[cache] Add configurable engine

### DIFF
--- a/cache/outputs.tf
+++ b/cache/outputs.tf
@@ -1,11 +1,15 @@
 output "endpoint" {
-  value = "${aws_elasticache_cluster.cache.configuration_endpoint}"
+  value = "${var.engine == "memcached" ? element(concat(aws_elasticache_cluster.memcache.*.configuration_endpoint, list("")), 0) : "" }"
+}
+
+output "nodes" {
+  value = "${aws_elasticache_cluster.redis.*.cache_nodes}"
 }
 
 output "endpoint_host" {
-  value = "${element(split(":",aws_elasticache_cluster.cache.configuration_endpoint), 0)}"
+  value = "${ var.engine == "memcached" ? element(split(":", join("", aws_elasticache_cluster.memcache.*.configuration_endpoint)), 0) : "" }"
 }
 
 output "endpoint_port" {
-  value = "${element(split(":",aws_elasticache_cluster.cache.configuration_endpoint), 1)}"
+  value = "${var.engine == "memcached" ? "11211" : "6379"}"
 }

--- a/cache/variables.tf
+++ b/cache/variables.tf
@@ -21,3 +21,7 @@ variable "client_security_groups" {
 variable "arena" {
   default = "core"
 }
+
+variable "engine" {
+  default = "memcached"
+}


### PR DESCRIPTION
Supports:
 - memcached (default)
 - redis

Fixes #257

Note:

Terraform doesn't really help with multi-splats

aws_elasticache_cluster.redis.*.cache_nodes.*.address

Isn't exactly somethign that can be optional, unfortunately.

So, the solution is JSON in Consul, and multiple outputs for the module